### PR TITLE
[23-06-27] jiwon.ts

### DIFF
--- a/useEventListener/jiwon.ts
+++ b/useEventListener/jiwon.ts
@@ -1,0 +1,63 @@
+import { getCurrentScope, onScopeDispose, toRef, watch } from 'vue'
+import { noop } from './index.test'
+
+const normalizeToArray = (value: any) => {
+  if (Array.isArray(value)) return value
+  else return [value]
+}
+
+const isTargetWindow = (target: any) => {
+  return typeof target === 'string'
+}
+
+export const useEventListener = (target: any, event: any, listener: any, options?: any) => {
+  const events = normalizeToArray(event)
+  const listeners = normalizeToArray(listener)
+  const targetRef = toRef(target)
+  const optionsRef = toRef(options)
+
+  const addEventListener = () => {
+    events.forEach(event => {
+      listeners.forEach(listener => {
+        targetRef.value.addEventListener(event, listener, optionsRef.value)
+      })
+    })
+  }
+
+  const removeEventListener = () => {
+    events.forEach(event => {
+      listeners.forEach(listener => {
+        targetRef.value.removeEventListener(event, listener, optionsRef.value)
+      })
+    })
+  }
+
+  watch(targetRef, (target, prevTarget) => {
+    if (!target) {
+      prevTarget.removeEventListener(event, listener, optionsRef.value)
+    }
+    useEventListener(target, event, listener, options)
+  })
+
+  watch(optionsRef, (options, prevOptions) => {
+    useEventListener(target, event, listener, options)
+  })
+
+  if (isTargetWindow(targetRef.value)) {
+    return useEventListener(window, target, event, listener)
+  }
+
+  if (targetRef.value) {
+    addEventListener()
+    if (getCurrentScope()) {
+      onScopeDispose(() => {
+        if (typeof targetRef.value === 'string') window.removeEventListener(event, listener, optionsRef.value)
+        else removeEventListener()
+      })
+      return
+    }
+    return removeEventListener
+  } else {
+    return noop
+  }
+}


### PR DESCRIPTION
### PR Summary
<!-- PR 내용을 간략하게 소개해주세요 -->
<!-- 구현 내용을 요약하거나, 구현하며 고민했던 내용 등을 포함하면 좋습니다 -->
- 마지막 테스트코드 (should auto re-register) 가 통과를 못해서 왜 안되나.. 찾는중입니다.
<img width="883" alt="image" src="https://github.com/da-in/tdd-challenge/assets/67074409/424327a1-c8a7-42d2-a8ff-5ce5cc571dda">

-  target이 ref로 들어올 때 이벤트 리스너 등록과 제거를 위해 반응형 변수로 바로 접근하는 부분이 문제인것 같긴 합니다.
테스트 코드 내에서 target.value이 변경되었을 때 useEventListener 내부의 watch에서 그 변화를 감지해 useEventListener를 재귀호출합니다. 이때 재호출된 useEventListener가 실행 완료된 후 초기에 호출된 useEventListener가 마저 실행되면서 addEventListener가 더 많이 등록되는 것 같습니다.

- 해당 부분 수정을 위해서는 target이 반응성 변수로 들어왔을 때 useEventListener 내부에서 target에서 반응성을 제거해주고, 반응성이 제거된 target으로 이벤트리스너 등록, 수정을 해주면 될,,거,, 라고 ,,생각합니다 (?) 
요건 고민이 더 필요해서 우선 현재 버전으로 올려봅니다.

### ISSUE NUMBER
<!-- 이슈 번호를 입력해주세요 -->
- #14 
